### PR TITLE
fix: typos

### DIFF
--- a/offensive-security/privilege-escalation/windows-namedpipes-privilege-escalation.md
+++ b/offensive-security/privilege-escalation/windows-namedpipes-privilege-escalation.md
@@ -4,7 +4,7 @@
 
 A `pipe` is a block of shared memory that processes can use for communication and data exchange.
 
-`Named Pipes` is a Windows mechanism that enables two unrelated processes to exchange data between themselves, even if the processes are located on two different networks. It's very simar to client/server architecture as notions such as `a named pipe server` and a named `pipe client` exist.
+`Named Pipes` is a Windows mechanism that enables two unrelated processes to exchange data between themselves, even if the processes are located on two different networks. It's very similar to client/server architecture as notions such as `a named pipe server` and a named `pipe client` exist.
 
 A named pipe server can open a named pipe with some predefined name and then a named pipe client can connect to that pipe via the known name. Once the connection is established, data exchange can begin.
 
@@ -89,7 +89,7 @@ Below shows the named pipe server and named pipe client working as expected:
 
 ![](<../../.gitbook/assets/Screenshot from 2019-04-02 23-44-22.png>)
 
-Worth nothing that the named pipes communication by default uses SMB protocol:
+Worth noting that the named pipes communication by default uses SMB protocol:
 
 ![](<../../.gitbook/assets/Screenshot from 2019-04-04 23-51-48.png>)
 


### PR DESCRIPTION
PR fixes typos in `Windows NamedPipes 101 + Privilege Escalation` page